### PR TITLE
Allow configuring a branch to checkout. Stable by default

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,3 +18,4 @@
 #
 
 default['github-enterprise']['backup']['repository'] = 'https://github.com/github/backup-utils.git'
+default['github-enterprise']['backup']['branch'] = 'stable'

--- a/libraries/provider_github_backup.rb
+++ b/libraries/provider_github_backup.rb
@@ -39,6 +39,7 @@ class Chef
         name = new_resource.parsed_name
         log_dir = new_resource.parsed_log_dir
         remote = node['github-enterprise']['backup']['repository']
+        branch = node['github-enterprise']['backup']['branch']
         dir = new_resource.parsed_dir
         data_dir = new_resource.parsed_data_dir
         config_file = "#{dir}/#{name}.config"
@@ -62,6 +63,7 @@ class Chef
           user new_resource.parsed_user
           group new_resource.parsed_group
           enable_submodules true
+          checkout_branch branch
         end
 
         ["#{dir}/bin/ghe-backup", "#{dir}/bin/ghe-restore", "#{dir}/bin/ghe-host-check"].each do |f|

--- a/test/integration/default/serverspec/ghe_utils_spec.rb
+++ b/test/integration/default/serverspec/ghe_utils_spec.rb
@@ -6,6 +6,10 @@ describe file('/opt/github-backup-utils') do
   it { should be_directory }
 end
 
+describe command('cd /opt/github-backup-utils && git branch') do
+  its(:stdout) { should match 'stable' }
+end
+
 describe file('/opt/github-backup-utils/bin/ghe-backup') do
   it { should be_executable }
 end


### PR DESCRIPTION
It's recommended to use "stable" branch https://github.com/github/backup-utils#getting-started

```
       Command "cd /opt/github-backup-utils && git branch"
         stdout
           should match "stable"
```